### PR TITLE
Check if given port is being used already

### DIFF
--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -50,6 +50,7 @@ module Hunter
         @auto_apply ||= Config.auto_apply
 
         raise "No port provided!" if !@port
+        raise "Provided port #{@port} is busy" if !`lsof -i:#{@port}`.empty?
 
         pidpath = ENV['flight_HUNTER_pidfile']
 


### PR DESCRIPTION
This PR introduces a small check in the `hunt` command to prevent it from attempting to run (and thus throwing a bad error message) when the given port is already busy, for example, when manually running `flight hunter hunt` while it is already being run through `flight service`.